### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal to the extracurricular activities signup page.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Configured with appropriate schedule (Wednesdays, 3:30 PM - 5:00 PM)
- Set max participants to 25
- Included description mentioning the GitHub Certifications program

## Fixes
Closes #6

## Context
Students reported that the GitHub Skills activity was announced in the school assembly but was missing from the signup website. This activity is part of the GitHub Certifications program and registrations close by the end of this week, making this time-sensitive.

The activity is now available for students to sign up alongside other activities like Chess Club, Programming Class, and Gym Class.